### PR TITLE
UC6 - Undo: aggiunta pre-condizione

### DIFF
--- a/PB/doc_esterna/analisi-dei-requisiti/analisi-dei-requisiti.tex
+++ b/PB/doc_esterna/analisi-dei-requisiti/analisi-dei-requisiti.tex
@@ -485,6 +485,7 @@ All'interno del sistema$_G$ Second Brain, abbiamo identificato le seguenti tipol
     \item \textbf{Pre-condizioni:}
         \begin{itemize}
             \item Il sistema ha registrato almeno una modifica nello storico delle operazioni recenti.
+            \item Il semplice caricamento di una nota non costituisce una modifica annullabile e non soddisfa la condizione precedente.
         \end{itemize}
     \item \textbf{Post-condizioni:}
         \begin{itemize}


### PR DESCRIPTION
modifica precondizine UC6 per impedire Undo su caricamento nota